### PR TITLE
when using yarn,cereal and vijos-sandbox will be in the same dir.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,8 @@
             "include_dirs": [
                 "<!@(node -p \"require('node-addon-api').include\")",
                 ".",
-                "node_modules/cereal/include"
+                "node_modules/cereal/include",
+                "../cereal/include"
             ],
             "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
             "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],


### PR DESCRIPTION
Bug Fix for #2 